### PR TITLE
Fixes boot error

### DIFF
--- a/src/Skybrud.Umbraco.Elements/Composers/ElementsComposer.cs
+++ b/src/Skybrud.Umbraco.Elements/Composers/ElementsComposer.cs
@@ -6,7 +6,7 @@ using Umbraco.Core.Composing;
 
 namespace Skybrud.Umbraco.Elements.Composers {
     
-    [RuntimeLevel(MinLevel = RuntimeLevel.Install)]
+    [RuntimeLevel(MinLevel = RuntimeLevel.Boot)]
     public class ElementsComposer : IUserComposer {
 
         public void Compose(Composition composition) {

--- a/src/Skybrud.Umbraco.Elements/Composers/ElementsComposer.cs
+++ b/src/Skybrud.Umbraco.Elements/Composers/ElementsComposer.cs
@@ -6,7 +6,7 @@ using Umbraco.Core.Composing;
 
 namespace Skybrud.Umbraco.Elements.Composers {
     
-    [RuntimeLevel(MinLevel = RuntimeLevel.Upgrade)]
+    [RuntimeLevel(MinLevel = RuntimeLevel.Install)]
     public class ElementsComposer : IUserComposer {
 
         public void Compose(Composition composition) {


### PR DESCRIPTION
This fixes a boot error that can occur when booting a project with this plugin on a fresh database i.e a Umbraco install.

By setting the runtime level to Install this injection error disappears. The value might need to be set to boot because it registers injectable classes which might be used anywhere in a project and therefore, might cause problems in the future. 